### PR TITLE
Use WooCommerce helpers for order notes and declare HPOS support

### DIFF
--- a/OpenFactura.php
+++ b/OpenFactura.php
@@ -1127,24 +1127,33 @@ function sub_menu_option_openfactura()
 
 function get_private_order_notes($order_id)
 {
-    global $wpdb;
-    $order_note = null;
-    $table_perfixed = $wpdb->prefix . 'comments';
-    $results = $wpdb->get_results("
-        SELECT *
-        FROM $table_perfixed
-        WHERE  `comment_post_ID` = $order_id
-        AND  `comment_type` LIKE  'order_note'
-    ");
-    foreach ($results as $note) {
-        $order_note[] = array(
-            'note_id' => $note->comment_ID,
-            'note_date' => $note->comment_date,
-            'note_author' => $note->comment_author,
-            'note_content' => $note->comment_content,
+    $order = wc_get_order($order_id);
+
+    if (!$order) {
+        return array();
+    }
+
+    $notes = wc_get_order_notes(
+        array(
+            'order_id' => $order->get_id(),
+            'type' => 'internal',
+        )
+    );
+
+    $order_notes = array();
+
+    foreach ($notes as $note) {
+        $date_created = $note->get_date_created();
+
+        $order_notes[] = array(
+            'note_id' => $note->get_id(),
+            'note_date' => $date_created ? $date_created->date('Y-m-d H:i:s') : '',
+            'note_author' => $note->get_author(),
+            'note_content' => $note->get_content(),
         );
     }
-    return $order_note;
+
+    return $order_notes;
 }
 
 /**
@@ -1155,7 +1164,7 @@ function so_payment_complete($order_id)
 {
     $order_notes = get_private_order_notes($order_id);
     //verificar que enlace de autoservicio no este creado previamente
-    if (isset($order_notes) && !empty($order_notes)) {
+    if (!empty($order_notes)) {
         foreach ($order_notes as $note) {
             $note_content = $note['note_content'];
             if (stristr($note_content, 'Obten tu documento tributario')) {
@@ -1939,7 +1948,7 @@ function my_completed_order_email_instructions($order, $sent_to_admin, $plain_te
     if ($openfactura_registry_active[0]->is_email_link_selfservice == '1') {
         $order_notes = get_private_order_notes($order->get_id());
         //verificar que enlace de autoservicio no este creado previamente
-        if (isset($order_notes) && !empty($order_notes)) {
+        if (!empty($order_notes)) {
             foreach ($order_notes as $note) {
                 $note_content = $note['note_content'];
                 if (stristr($note_content, 'Obten tu documento tributario')) {

--- a/Woocommerce-OpenFactura.php
+++ b/Woocommerce-OpenFactura.php
@@ -28,3 +28,16 @@ include('OpenFactura.php');
  * Create table openfactura_registry
  */
 register_activation_hook(__FILE__, 'openfactura_registry');
+
+add_action(
+    'before_woocommerce_init',
+    function () {
+        if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+                'custom_order_tables',
+                __FILE__,
+                true
+            );
+        }
+    }
+);


### PR DESCRIPTION
## Summary
- replace direct database reads for order notes with WooCommerce helper APIs and preserve the expected data structure
- update order completion and email hooks to rely on the normalized helper output when checking for self-service links
- declare HPOS custom order table compatibility during initialization

## Testing
- php -l OpenFactura.php
- php -l Woocommerce-OpenFactura.php

------
https://chatgpt.com/codex/tasks/task_e_68d178cd9ef4832bbef042d7286773db